### PR TITLE
This refactors IPBus code to handle endianness better

### DIFF
--- a/docs/cookbook.rst
+++ b/docs/cookbook.rst
@@ -160,7 +160,7 @@ One might like to be able to generate a full test of the ``ironman`` suite by se
 ...
 >>> d = Deferred().addCallback(IPBusPacket).addCallback(j).addCallback(buildResponsePacket).addCallback(printPacket)
 >>> d.callback('200000f02000010f00000002'.decode('hex'))  # read the upper limit
-raw: '200000f02000010000000039'
+raw: '200000f02000010039000000'
 Container:
     endian = (enum) BIG 240
     header = Container:
@@ -179,7 +179,7 @@ Container:
                 info_code = (enum) SUCCESS 0
             address = None
             data = ListContainer:
-                57
+                956301312
     status = None
     resend = None
 >>>

--- a/docs/cookbook.rst
+++ b/docs/cookbook.rst
@@ -33,8 +33,7 @@ Parsing an IPBus Packet
 >>> p = IPBusConstruct.parse(data)
 >>> print p
 Container:
-    pointer = 240
-    bigendian = True
+    endian = (enum) BIG 240
     header = Container:
         protocol_version = 2
         reserved = 0
@@ -163,8 +162,7 @@ One might like to be able to generate a full test of the ``ironman`` suite by se
 >>> d.callback('200000f02000010f00000002'.decode('hex'))  # read the upper limit
 raw: '200000f02000010000000039'
 Container:
-    pointer = 240
-    bigendian = True
+    endian = (enum) BIG 240
     header = Container:
         protocol_version = 2
         reserved = 0

--- a/ironman/communicator.py
+++ b/ironman/communicator.py
@@ -63,7 +63,7 @@ class Jarvis(object):
             raise KeyError(transaction.address)
         protocol = protocol()
         if transaction.header.type_id == 'READ':
-            return IPBusWords.parse(protocol.read(transaction.address, transaction.header.words)).data
+            return IPBusWords.parse(protocol.read(transaction.address, transaction.header.words))
         elif transaction.header.type_id == 'WRITE':
             protocol.write(transaction.address, bytes(bytearray(transaction.data)))
             return

--- a/ironman/constructs/ipbus.py
+++ b/ironman/constructs/ipbus.py
@@ -1,9 +1,12 @@
 from construct import Array, BitsInteger, BitStruct, Enum, GreedyRange, Struct, Int8ub, Int32ub, Int32ul, Int32sb, Int32sl, OneOf, Nibble, Octet, If, IfThenElse, ByteSwapped, this, Computed, Switch, Pointer, Check, Terminated
 from ironman.globals import IPBUS_VERSION
+import sys
 
 _IPBusWordFactory = lambda this: IfThenElse(this._.endian=='BIG', Int32ub, Int32ul)
 _IPBusSignedWordFactory = lambda this: IfThenElse(this._.endian=='BIG', Int32sb, Int32sl)
 IPBusWords = GreedyRange(Int32ub)
+if sys.byteorder == 'little':
+  IPBusWords = GreedyRange(Int32ul)
 
 PacketHeaderStruct = BitStruct(
                         "protocol_version" / OneOf(Nibble, [IPBUS_VERSION]),

--- a/ironman/interfaces.py
+++ b/ironman/interfaces.py
@@ -15,7 +15,6 @@ class IIPBusPacket(Interface):
     response = Attribute("The parsed response packet")
     _raw = Attribute("The raw request packet")
     raw = Attribute("The raw datagram blob.")
-    littleendian = Attribute("A flag dictating whether the datagram is received/sent in little-endian.")
     protocol_version = Attribute("The packet header protocol version. This does not check that the encapsulated transactions also match.")
     reserved = Attribute("Reserved. Should be 0x0.")
     packet_id = Attribute("The id of the ipbus packet.")

--- a/ironman/packet.py
+++ b/ironman/packet.py
@@ -14,11 +14,7 @@ class IPBusPacket(object):
         self.request = None
         self.response = None
         self._raw = blob
-        # if little-endian, we need to swap when reading and writing
-        self.littleendian = bool((ord(self._raw[0])&0xf0)>>4 == 0xf)
-        # do some flipping
         raw = self.raw
-        if self.littleendian: raw = byteswap(raw)
         self.request = IPBusConstruct.parse(raw)
         self.response = IPBusConstruct.parse(raw)
 

--- a/tests/constructs/test_ipbus.py
+++ b/tests/constructs/test_ipbus.py
@@ -1,4 +1,4 @@
-from ironman.constructs.ipbus import IPBusConstruct, PacketHeaderStruct, ControlHeaderStruct
+from ironman.constructs.ipbus import IPBusConstruct, IPBusWords, PacketHeaderStruct, ControlHeaderStruct
 from ironman.globals import TESTPACKETS
 from construct import StreamError, ValidationError
 
@@ -29,6 +29,18 @@ class TestIPBusControlPacket:
         """
         with pytest.raises(StreamError) as e:
             ControlHeaderStruct.parse(data)
+
+def test_data_endianness_switch():
+    in_data = '200000f020000100deadbeef'.decode('hex')
+    packet = IPBusConstruct.parse(in_data)
+
+    assert packet.bigendian
+
+    packet.pointer=0x0 # make it little-endian
+    out_data = IPBusConstruct.build(packet)
+    assert out_data.encode('hex') == 'f000002000010020efbeadde'
+
+    assert IPBusConstruct.parse(out_data).bigendian == False
 
 """
 foo = IPBusConstruct.parse(b'\x20\x00\x00\xf0\x20\x00\x01\x0f\x00\x00\x00\x03')

--- a/tests/constructs/test_ipbus.py
+++ b/tests/constructs/test_ipbus.py
@@ -31,16 +31,16 @@ class TestIPBusControlPacket:
             ControlHeaderStruct.parse(data)
 
 def test_data_endianness_switch():
-    in_data = '200000f020000100deadbeef'.decode('hex')
-    packet = IPBusConstruct.parse(in_data)
-
+    data_big = '200000f020000100deadbeef'.decode('hex')
+    packet = IPBusConstruct.parse(data_big)
     assert packet.endian == 'BIG'
+    assert packet.transactions[0].data == [0xdeadbeef]
 
     packet.endian='LITTLE' # make it little-endian
-    out_data = IPBusConstruct.build(packet)
-    assert out_data.encode('hex') == 'f000002000010020efbeadde'
-
-    assert IPBusConstruct.parse(out_data).endian == 'LITTLE'
+    data_lil = IPBusConstruct.build(packet)
+    assert data_lil.encode('hex') == 'f000002000010020efbeadde'
+    assert IPBusConstruct.parse(data_lil).endian == 'LITTLE'
+    assert IPBusConstruct.parse(data_lil).transactions[0].data == [0xdeadbeef]
 
 """
 foo = IPBusConstruct.parse(b'\x20\x00\x00\xf0\x20\x00\x01\x0f\x00\x00\x00\x03')

--- a/tests/constructs/test_ipbus.py
+++ b/tests/constructs/test_ipbus.py
@@ -34,13 +34,13 @@ def test_data_endianness_switch():
     in_data = '200000f020000100deadbeef'.decode('hex')
     packet = IPBusConstruct.parse(in_data)
 
-    assert packet.bigendian
+    assert packet.endian == 'BIG'
 
-    packet.pointer=0x0 # make it little-endian
+    packet.endian='LITTLE' # make it little-endian
     out_data = IPBusConstruct.build(packet)
     assert out_data.encode('hex') == 'f000002000010020efbeadde'
 
-    assert IPBusConstruct.parse(out_data).bigendian == False
+    assert IPBusConstruct.parse(out_data).endian == 'LITTLE'
 
 """
 foo = IPBusConstruct.parse(b'\x20\x00\x00\xf0\x20\x00\x01\x0f\x00\x00\x00\x03')

--- a/tests/test_packet.py
+++ b/tests/test_packet.py
@@ -47,8 +47,8 @@ class TestIPBusControlPacketParse:
 
     def test_packet_swap(self):
         swapped_packet = IPBusPacket(byteswap(self.packet.raw))
-        assert self.packet == swapped_packet
-        assert not self.packet != swapped_packet
+        assert self.packet.request.endian != swapped_packet.request.endian
+        assert self.packet.request.transactions == swapped_packet.request.transactions
 
 class TestIPBusControlPacketSimpleParse:
     @pytest.fixture(autouse=True)


### PR DESCRIPTION
This does two things:
- `_IPBusWordFactory()` and `_IPBusSignedWordFactory()` are created to help generate the correct endianness needed when incoming packets are made
- `pointer` and `bigendian` are combined into a single enum `(BIG, LITTLE)` to keep track of the endianness of the packet.
